### PR TITLE
Fix: use IndexedDB to bypass storage quota

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@solid-primitives/deep": "^0.2.8",
         "@techstark/opencv-js": "^4.9.0-release.3",
         "debounce": "^2.1.0",
+        "localforage": "^1.10.0",
         "potpack": "^2.0.0",
         "solid-js": "^1.8.15"
       },
@@ -4251,6 +4252,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -4704,6 +4710,14 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
@@ -4714,6 +4728,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "dependencies": {
+        "lie": "3.1.1"
       }
     },
     "node_modules/locate-path": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@solid-primitives/deep": "^0.2.8",
     "@techstark/opencv-js": "^4.9.0-release.3",
     "debounce": "^2.1.0",
+    "localforage": "^1.10.0",
     "potpack": "^2.0.0",
     "solid-js": "^1.8.15"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,7 +77,8 @@ function App() {
 }
 
 function TextureRipper() {
-  const [store, { setFile }] = useAppStore().file;
+  const { setFile } = useAppStore();
+  const [store] = useAppStore().file;
 
   const dnd = createDnd(setFile);
   const resize = createResize();

--- a/src/editor/Editor.tsx
+++ b/src/editor/Editor.tsx
@@ -26,7 +26,9 @@ export function Editor() {
 
   return (
     <Container>
-      <ImageBackground src={url()} onLoadRef={setImageRef} />
+      <Show when={store.blob.size > 0}>
+        <ImageBackground src={url()} onLoadRef={setImageRef} />
+      </Show>
       <Show when={imageRef()}>
         <DrawingBoard imageRef={imageRef()!} />
       </Show>

--- a/src/editor/Editor.tsx
+++ b/src/editor/Editor.tsx
@@ -14,7 +14,7 @@ const Container = styled("div", {
 });
 
 export function Editor() {
-  const [store, api] = useAppStore().file;
+  const [store] = useAppStore().file;
   const url = createMemo(() => URL.createObjectURL(store.blob));
 
   // image reference is pointing at the same img element,

--- a/src/store/file.ts
+++ b/src/store/file.ts
@@ -12,10 +12,6 @@ interface StoreData {
 export function createFileStore() {
   const [store, setStore] = createStore<StoreData>(getDefaultStore());
 
-  async function setFile(blob: Blob) {
-    setStore({ blob });
-  }
-
   const [image] = createResource(
     () => store.blob,
     async (blob) => {
@@ -26,7 +22,7 @@ export function createFileStore() {
     }
   );
 
-  const api = { setFile, image };
+  const api = { image };
 
   return [store, api, setStore] as const;
 }

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -83,12 +83,13 @@ function createPersistence(state: Stores) {
     return true as const;
   });
 
-  const storageDependencies = () =>
-    [
+  function storageDependencies() {
+    return [
       state.file[0].blob,
       state.editor[0].quads,
       trackStore(state.editor[0].points),
     ] as const;
+  }
 
   function save() {
     if (!loaded()) return;
@@ -113,6 +114,7 @@ async function loadFromLocalStorage(state: Stores) {
     const { blob, points, quads } = data;
     state.file[2]({ blob });
     state.editor[2]({ points, quads });
+    console.log("loaded from local storage", unwrap(state.editor[0]));
   } catch (e) {
     console.error(e);
     return;

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -21,6 +21,7 @@ interface Stores {
   texture: TextureStore;
   computed: ComputedState;
   storage: LocalForage;
+  setFile(blob: Blob): void;
 }
 
 interface PersistState {
@@ -55,19 +56,16 @@ export function AppStoreProvider(props: { children: JSXElement }) {
     texture,
     computed,
     storage,
+    setFile,
   } satisfies Stores;
 
   createPersistence(state);
 
-  createEffect(
-    on(
-      () => file[0].blob,
-      () => {
-        editor[1].reset();
-        texture[1].reset();
-      }
-    )
-  );
+  function setFile(blob: Blob) {
+    file[2]({ blob });
+    editor[1].reset();
+    texture[1].reset();
+  }
 
   return (
     <StoreContext.Provider value={state}>
@@ -110,11 +108,9 @@ async function loadFromLocalStorage(state: Stores) {
   if (data.version !== version) return;
 
   try {
-    console.log("loading from local storage", data);
     const { blob, points, quads } = data;
     state.file[2]({ blob });
     state.editor[2]({ points, quads });
-    console.log("loaded from local storage", unwrap(state.editor[0]));
   } catch (e) {
     console.error(e);
     return;
@@ -132,6 +128,5 @@ async function saveToLocalStorage(state: Stores) {
     quads: unwrap(quads),
   } satisfies PersistState;
 
-  console.log("saving to local storage", data);
   state.storage.setItem<PersistState>(key, data);
 }

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -10,6 +10,7 @@ import {
   onMount,
   useContext,
 } from "solid-js";
+import { unwrap } from "solid-js/store";
 import { ComputedState, createComputedState } from "./computed";
 import { EditorStore, PointId, Quad, createEditorStore } from "./editor";
 import { FileStore, createFileStore } from "./file";
@@ -100,6 +101,12 @@ async function saveToLocalStorage(state: Stores) {
   const { blob } = state.file[0];
   const { points, quads } = state.editor[0];
 
-  const data = { version, blob, points, quads } satisfies PersistState;
+  const data = {
+    version,
+    blob,
+    points: unwrap(points),
+    quads: unwrap(quads),
+  } satisfies PersistState;
+
   state.storage.setItem<PersistState>(key, data);
 }

--- a/src/toolbar/Upload.tsx
+++ b/src/toolbar/Upload.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/styles";
 import { createSignal } from "solid-js";
 
 export function Upload() {
-  const [_, { setFile }] = useAppStore().file;
+  const { setFile } = useAppStore();
   const [input, setInput] = createSignal<HTMLInputElement>();
 
   function show() {


### PR DESCRIPTION
After some time browser will complain about exceeding storage quota. With `localforage` library we can switch to IndexedDB, which does not have this problem.

Also, removed reset state effect on file change with direct method for file change.